### PR TITLE
fix clang compiler error

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -39,6 +39,8 @@
 #include "src/image.h"
 #include "src/common.h"
 
+PHP_WKHTMLTOX_API zend_class_entry* wkhtmltox_image_ce;
+
 zend_object_handlers php_wkhtmltoimage_handlers;
 
 void php_wkhtmltoimage_warn(php_wkhtmltoimage_t *w, const char *warn) {

--- a/src/image.h
+++ b/src/image.h
@@ -35,8 +35,6 @@
 PHP_MINIT_FUNCTION(wkhtmltox_image);
 PHP_MSHUTDOWN_FUNCTION(wkhtmltox_image);
 
-PHP_WKHTMLTOX_API zend_class_entry* wkhtmltox_image_ce;
-
 typedef struct _php_wkhtmltoimage_t {
 	wkhtmltoimage_converter *converter;
 	wkhtmltoimage_global_settings *settings;

--- a/src/pdf.c
+++ b/src/pdf.c
@@ -39,6 +39,9 @@
 #include "src/pdf.h"
 #include "src/common.h"
 
+PHP_WKHTMLTOX_API zend_class_entry* wkhtmltox_pdf_ce;
+PHP_WKHTMLTOX_API zend_class_entry* wkhtmltox_pdf_object_ce;
+
 zend_object_handlers php_wkhtmltopdf_handlers;
 zend_object_handlers php_wkhtmltopdf_object_handlers;
 

--- a/src/pdf.h
+++ b/src/pdf.h
@@ -35,9 +35,6 @@
 PHP_MINIT_FUNCTION(wkhtmltox_pdf);
 PHP_MSHUTDOWN_FUNCTION(wkhtmltox_pdf);
 
-PHP_WKHTMLTOX_API zend_class_entry* wkhtmltox_pdf_ce;
-PHP_WKHTMLTOX_API zend_class_entry* wkhtmltox_pdf_object_ce;
-
 typedef struct _php_wkhtmltopdf_t {
 	wkhtmltopdf_converter *converter;
 	wkhtmltopdf_global_settings *settings;


### PR DESCRIPTION
move variables decleard in header file to the C file to avoid clang compiler error.

> ### below is the error:

```
duplicate symbol '_wkhtmltox_pdf_object_ce' in:
    .libs/wkhtmltox.o
    src/.libs/pdf.o
duplicate symbol '_wkhtmltox_pdf_ce' in:
    .libs/wkhtmltox.o
    src/.libs/pdf.o
duplicate symbol '_wkhtmltox_image_ce' in:
    .libs/wkhtmltox.o
    src/.libs/image.o
ld: 3 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```